### PR TITLE
Catch a greater variety of exceptions in Bind combinator

### DIFF
--- a/lib/deferrable_gratification/combinators/bind.rb
+++ b/lib/deferrable_gratification/combinators/bind.rb
@@ -76,7 +76,7 @@ module DeferrableGratification
       def run_bound_proc(*args)
         begin
           second = @proc.call(*args)
-        rescue => error
+        rescue Exception => error
           self.fail(error)
         else
           # We expect the block to return a Deferrable, on which we can set


### PR DESCRIPTION
If inside a `bind` or `transform` block you raise an exception that's not a subclass of `RuntimeError` (e.g. `SyntaxError`), EventMachine transforms that exception into something incomprehensible and misleading.

For example, this works as expected:

``` ruby
EM.run do
  EM::HttpRequest.new('http://www.google.com/').get.transform do |http|
    ERB.new('<%= http.response_header.status %>').result(binding)
  end.callback{|result| puts result; EM.stop }
end
# prints: 200
```

But if I introduce a syntax error into the ERB template…

``` ruby
EM.run do
  EM::HttpRequest.new('http://www.google.com/').get.transform do |http|
    ERB.new('<%= http.response_header.status end %>').result(binding) # syntax error!
  end.callback{|result| puts result; EM.stop }
end
```

…I get a rather strange exception:

```
EventMachine::ConnectionNotBound: recieved ConnectionUnbound for an unknown signature: 12
    from /Users/martin/.rvm/gems/ruby-1.8.7-p352@rapportive/gems/eventmachine-0.12.10/lib/eventmachine.rb:1425:in `event_callback'
    from /Users/martin/.rvm/gems/ruby-1.8.7-p352@rapportive/gems/eventmachine-0.12.10/lib/eventmachine.rb:263:in `release_machine'
    from /Users/martin/.rvm/gems/ruby-1.8.7-p352@rapportive/gems/eventmachine-0.12.10/lib/eventmachine.rb:263:in `run'
    from (irb):45
```

…whereas I'd rather the errback to be called with the syntax error, so that it can be handled gracefully.
