### PR TITLE
Add #safe_callback and #safe_errback.

### DIFF
--- a/lib/deferrable_gratification/fluent.rb
+++ b/lib/deferrable_gratification/fluent.rb
@@ -21,6 +21,23 @@ module DeferrableGratification
       self
     end
 
+    # Register +block+ to be called on success.
+    #
+    # If the block raises an exception, the deferrable will be failed.
+    #
+    # @return [Deferrable, Fluent] +self+
+    #
+    # @see EventMachine::Deferrable#errback
+    def safe_callback(&block)
+      callback do |*args|
+        begin
+          yield *args
+        rescue => e
+          fail e
+        end
+      end
+    end
+
     # Register +block+ to be called on failure.
     #
     # @return [Deferrable, Fluent] +self+
@@ -29,6 +46,24 @@ module DeferrableGratification
     def errback(&block)
       super(&block)
       self
+    end
+
+    # Register +block+ to be called on success.
+    #
+    # If the block raises an exception, the deferrable will be re-failed
+    # with the new exception.
+    #
+    # @return [Deferrable, Fluent] +self+
+    #
+    # @see EventMachine::Deferrable#errback
+    def safe_errback(&block)
+      errback do |*args|
+        begin
+          yield *args
+        rescue => e
+          fail e
+        end
+      end
     end
 
     # Ensure that if this Deferrable doesn't either succeed or fail within the

--- a/spec/deferrable_gratification/fluent_spec.rb
+++ b/spec/deferrable_gratification/fluent_spec.rb
@@ -84,4 +84,31 @@ describe DeferrableGratification::Fluent do
       end
     end
   end
+
+  describe '#safe_callback' do
+    describe 'DG::success("bar").safe_callback{ |arg| raise "foo#{arg}" }' do
+      subject{ DG::success("bar").safe_callback{ |arg| raise "foo#{arg}" } }
+
+      it 'should not raise an exception' do
+        lambda{ subject }.should_not raise_error
+      end
+
+      it 'should fail with foobar' do
+        subject.should fail_with /foobar/
+      end
+    end
+  end
+
+  describe '#safe_errback' do
+    describe 'DG::failure(ArgumentErrror.new("bar")).safe_errback{ |err| raise "foo#{err.message}" }' do
+      subject{ DG::failure(ArgumentError.new("bar")).safe_errback{ |err| raise "foo#{err.message}" } }
+      it 'should not raise an exception' do
+        lambda{ subject }.should_not raise_error
+      end
+
+      it 'should fail with foobar' do
+        subject.should fail_with /foobar/
+      end
+    end
+  end
 end


### PR DESCRIPTION
Removes some of the temptation to use "#transform" and
"#transform_error" to acheive this effect.
