### PR TITLE
`DG::in_parallel`.

### DIFF
--- a/lib/deferrable_gratification/combinators.rb
+++ b/lib/deferrable_gratification/combinators.rb
@@ -280,6 +280,20 @@ module DeferrableGratification
         Join::FirstSuccess.setup!(*operations)
       end
 
+
+      # Combinator that waits for all of the supplied asynchronous operations
+      # to succeed or fail, and then succeeds with an Array of the successes and
+      # an Array of the failures.
+      #
+      # @param [*Deferrable] *operations
+      #
+      # @return [Deferrable] a deferred status that will succeed with the Array
+      #   of all +operations+ that succeeded, and the Array of all +operations+
+      #   that failed.
+      def in_parallel(*operations)
+        Join::InParallel.setup!(*operations)
+      end
+
       # Combinator that repeatedly executes the supplied block until it
       # succeeds, then succeeds itself with the eventual result.
       #

--- a/lib/deferrable_gratification/combinators.rb
+++ b/lib/deferrable_gratification/combinators.rb
@@ -261,7 +261,9 @@ module DeferrableGratification
       #   passed an +Enumerable+ containing the results of those operations
       #   that succeeded.
       def join_successes(*operations)
-        Join::Successes.setup!(*operations)
+        in_parallel(*operations).transform do |successes, failures|
+          successes
+        end
       end
 
       # Combinator that waits for any of the supplied asynchronous operations

--- a/lib/deferrable_gratification/combinators/join.rb
+++ b/lib/deferrable_gratification/combinators/join.rb
@@ -49,31 +49,6 @@ module DeferrableGratification
       end
 
 
-      # Combinator that waits for all of the supplied asynchronous operations
-      # to succeed or fail, then succeeds with the results of all those
-      # operations that were successful.
-      #
-      # This Deferrable will never fail.  It may also never succeed, if _any_
-      # of the supplied operations does not either succeed or fail.
-      #
-      # The successful results are guaranteed to be in the same order as the
-      # operations were passed in (which may _not_ be the same as the
-      # chronological order in which they succeeded).
-      #
-      # You probably want to call {ClassMethods#join_successes} rather than
-      # using this class directly.
-      class Successes < Join
-        private
-        def done?
-          all_completed?
-        end
-
-        def finish
-          succeed(successes)
-        end
-      end
-
-
       # Combinator that waits for any of the supplied asynchronous operations
       # to succeed, and succeeds with the result of the first (chronologically)
       # to do so.

--- a/lib/deferrable_gratification/combinators/join.rb
+++ b/lib/deferrable_gratification/combinators/join.rb
@@ -95,6 +95,26 @@ module DeferrableGratification
       end
 
 
+      # Combinator that waits for all of the supplied asynchronous operations
+      # to succeed or fail, and the succeeds with a list of the successes and
+      # a list of the failures.
+      #
+      # This deferrable will never fail. It may never succeed if one of
+      # the supplied operations never completes.
+      #
+      # You probably want to call {ClassMethods#in_parallel} rather than
+      # using this class directly.
+      class InParallel < Join
+        private
+        def done?
+          all_completed?
+        end
+
+        def finish
+          succeed(successes, failures)
+        end
+      end
+
       private
       def successes
         without_sentinels(@successes)

--- a/spec/deferrable_gratification/in_parallel_spec.rb
+++ b/spec/deferrable_gratification/in_parallel_spec.rb
@@ -1,0 +1,42 @@
+require 'deferrable_gratification'
+
+describe DeferrableGratification::Combinators do
+  describe '.in_parallel' do
+
+    describe 'with successful operations' do
+      subject do
+        DG.in_parallel(
+          DummyDB.query(:id, :name => 'Sam'),
+          DummyDB.query(:age, :id => 42)
+        )
+      end
+
+      before do
+        DummyDB.stub_successful_query(:id, :name => 'Sam') { 42 }
+        DummyDB.stub_successful_query(:age, :id => 42) { 26 }
+      end
+
+      it "should succeed" do
+        subject.should succeed_with [42, 26], []
+      end
+    end
+
+    describe 'with a mix of operations' do
+      subject do
+        DG.in_parallel(
+          DummyDB.query(:id, :name => 'Sam'),
+          DummyDB.query(:age, :id => 42)
+        )
+      end
+
+      before do
+        DummyDB.stub_successful_query(:id, :name => 'Sam') { 42 }
+        DummyDB.stub_failing_query(:age, :id => 42) { 'oops' }
+      end
+
+      it "should succeed" do
+        subject.should succeed_with [42], ['oops']
+      end
+    end
+  end
+end


### PR DESCRIPTION
Like join_successes, but preserves the failures too.
